### PR TITLE
[AWS] Add automatic catalog update for AWS with github action (resubmit #4)

### DIFF
--- a/.github/workflows/update-aws-catalog.yml
+++ b/.github/workflows/update-aws-catalog.yml
@@ -1,0 +1,54 @@
+name: "update-aws-catalog"
+on:
+  schedule:
+    - cron:  '00 */7 * * *'    # Every 7 hours (coprimes with 24)
+    # The frequency can be tuned for the trade-off between
+    # freshness of the price and github action cost/user downloading
+    # overhead of the update.
+    # _UPDATE_FREQUENCY_HOURS in `aws_catalog.py` need to be updated
+    # accordingly, if this is changed.
+
+jobs:
+  update_aws_catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone SkyPilot repo
+        uses: actions/checkout@v3
+        with:
+          repository: skypilot-org/skypilot
+          ref: update-catalog-from-host #!!! remove this when merging to master
+          path: sky
+      - name: Clone Catalog repo
+        uses: actions/checkout@v3
+        with:
+          path: catalogs
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip' # caching pip dependencies
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          cd sky
+          pip install ".[aws]"
+
+      - name: Run fetch_aws
+        run: |
+          version=$(python -c 'import sky; print(sky.clouds.service_catalog.constants.CATALOG_SCHEMA_VERSION)')
+          mkdir -p catalogs/catalogs/$version
+          cd catalogs/catalogs/$version
+          python -m sky.clouds.service_catalog.data_fetchers.fetch_aws --all-regions --no-az-mappings
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Commit catalog
+        run: |
+          version=$(python -c 'import sky; print(sky.clouds.service_catalog.constants.CATALOG_SCHEMA_VERSION)')
+          cd catalogs
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m"[Bot] Update AWS catalog $version (scheduled at $(date))"
+          git push


### PR DESCRIPTION
This PR resubmits #4, since the GitHub marked it as merged when the #6 was merged.

This PR adds github action for updating the catalog for AWS periodically.

This should go in together with https://github.com/skypilot-org/skypilot/pull/1451

The AWS credentials with only instance/price access (policy is shown below) are added to the repo secrets.
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/6753189/204071831-45d98753-1193-4aa4-afa1-798dde8b5a18.png">

Future TODOs:
- [x] Actively download the catalog when outdated in the SkyPilot code. (done for AWS in https://github.com/skypilot-org/skypilot/pull/1451)
- [x] Use AZID instead of AZ name for the price to get the correct price.

Tested:
- [x] https://github.com/Michaelvll/skypilot-catalog/actions/workflows/update-aws-catalog.yml

TODO:
- [ ] remove the following line in the github action file:
```
          ref: update-catalog-from-host #!!! remove this when merging to master
```