### PR TITLE
A quick fix for CI

### DIFF
--- a/catalogs/v5/gcp/vms.csv
+++ b/catalogs/v5/gcp/vms.csv
@@ -2036,6 +2036,7 @@ g1-small,,,0.5,1.7,,0.0257,0.007,us-central1,us-central1-a
 g1-small,,,0.5,1.7,,0.0257,0.007,us-central1,us-central1-b
 g1-small,,,0.5,1.7,,0.0257,0.007,us-central1,us-central1-c
 g1-small,,,0.5,1.7,,0.0257,0.007,us-central1,us-central1-f
+n1-highmem-8,,,8.0,52.0,,0.473212,0.099624,us-central2,us-central2-b
 n1-standard-1,,,1.0,3.75,,0.04749975,0.01,us-west1,us-west1-a
 n1-standard-1,,,1.0,3.75,,0.04749975,0.01,us-west1,us-west1-b
 n1-standard-1,,,1.0,3.75,,0.04749975,0.01,us-west1,us-west1-c


### PR DESCRIPTION
For https://github.com/skypilot-org/skypilot-catalog/pull/16#issuecomment-1463353529.
The reason was our catalog is missing `n1-highmem-8` for `us-central2` region, where the v4 tpu resides. so when `sky launch --gpus v4-8` would cause `ResourcesUnavailableError`.

This is not the complete fix but the smallest change to unblock the CI test.
The correct fix would be to complete the catalog for `us-central2` or probably make our test a bit more robust.