### PR TITLE
Add ubuntu image for GCP

### DIFF
--- a/catalogs/v5/gcp/images.csv
+++ b/catalogs/v5/gcp/images.csv
@@ -3,5 +3,4 @@ skypilot:cpu-debian-10,,debian,10,projects/deeplearning-platform-release/global/
 skypilot:k80-debian-10,,debian,10,projects/deeplearning-platform-release/global/images/common-cu113-v20220701,20220701
 skypilot:gpu-debian-10,,debian,10,projects/deeplearning-platform-release/global/images/common-cu113-v20221215,20221215
 skypilot:cpu-ubuntu-2004,,ubuntu,2004,projects/deeplearning-platform-release/global/images/common-cpu-v20230501-ubuntu-2004-py37,20230501
-skypilot:k80-ubuntu-2004,,ubuntu,2004,projects/deeplearning-platform-release/global/images/common-cu113-v20230501-ubuntu-2004-py37,20230501
 skypilot:gpu-ubuntu-2004,,ubuntu,2004,projects/deeplearning-platform-release/global/images/common-cu113-v20230501-ubuntu-2004-py37,20230501

--- a/catalogs/v5/gcp/images.csv
+++ b/catalogs/v5/gcp/images.csv
@@ -2,4 +2,6 @@ Tag,Region,OS,OSVersion,ImageId,CreationDate
 skypilot:cpu-debian-10,,debian,10,projects/deeplearning-platform-release/global/images/common-cpu-v20221215,20221215
 skypilot:k80-debian-10,,debian,10,projects/deeplearning-platform-release/global/images/common-cu113-v20220701,20220701
 skypilot:gpu-debian-10,,debian,10,projects/deeplearning-platform-release/global/images/common-cu113-v20221215,20221215
-
+skypilot:cpu-ubuntu-2004,,ubuntu,2004,projects/deeplearning-platform-release/global/images/common-cpu-v20230501-ubuntu-2004-py37,20230501
+skypilot:k80-ubuntu-2004,,ubuntu,2004,projects/deeplearning-platform-release/global/images/common-cu113-v20230501-ubuntu-2004-py37,20230501
+skypilot:gpu-ubuntu-2004,,ubuntu,2004,projects/deeplearning-platform-release/global/images/common-cu113-v20230501-ubuntu-2004-py37,20230501


### PR DESCRIPTION
https://github.com/skypilot-org/skypilot/pull/1641

We do not add the K80 image, as K80 has been deprecated and the ubuntu image does not work well with K80 (need to manually re-install the nvidia driver < 470 for K80)