### PR TITLE
[k8s] Add `images.csv` for Kubernetes

### DIFF
--- a/catalogs/v5/kubernetes/images.csv
+++ b/catalogs/v5/kubernetes/images.csv
@@ -1,0 +1,3 @@
+Tag,Region,OS,OSVersion,ImageId,CreationDate
+skypilot:cpu-debian-11,,debian,11,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest,20230601
+skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest,20230601

--- a/catalogs/v5/kubernetes/images.csv
+++ b/catalogs/v5/kubernetes/images.csv
@@ -1,3 +1,3 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
-skypilot:cpu-debian-11,,debian,11,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest,20230601
+skypilot:cpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest,20230601
 skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest,20230601


### PR DESCRIPTION
Closes https://github.com/skypilot-org/skypilot/issues/2430. Adds a `images.csv` to map skypilot image tags to underlying container registry tags.