### PR TITLE
[Performance] Catalog add Azure custom image for A10

### DIFF
--- a/catalogs/v5/azure/images.csv
+++ b/catalogs/v5/azure/images.csv
@@ -5,3 +5,4 @@ skypilot:v1-ubuntu-2004,,Ubuntu,20.04,microsoft-dsvm:ubuntu-2004:2004:21.11.04
 skypilot:custom-gpu-ubuntu-v1,,Ubuntu,22.04,/CommunityGalleries/skypilot-5c783dcb-c1d8-48ca-a5eb-0cee59e165fd/Images/skypilot-gpu-gen1,canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen1
 skypilot:custom-cpu-ubuntu-v2,,Ubuntu,22.04,/CommunityGalleries/skypilot-fc3311ab-d34c-4589-b2fb-a95b8a84ceb1/Images/skypilot-cpu-gen2,canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2
 skypilot:custom-gpu-ubuntu-v2,,Ubuntu,22.04,/CommunityGalleries/skypilot-fc3311ab-d34c-4589-b2fb-a95b8a84ceb1/Images/skypilot-gpu-gen2,canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2
+skypilot:custom-gpu-ubuntu-v2-grid,,Ubuntu,22.04,/CommunityGalleries/skypilot-5c783dcb-c1d8-48ca-a5eb-0cee59e165fd/Images/skypilot-gpu-gen2-grid,canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2


### PR DESCRIPTION
Tested with `time sky launch --image-id /CommunityGalleries/skypilot-5c783dcb-c1d8-48ca-a5eb-0cee59e165fd/Images/skypilot-gpu-gen2-grid --region=eastus --cloud azure --gpus A10 -y`