### PR TITLE
GitHub Actions catalog to AWS S3 for mirroring

### DIFF
--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
           aws --version
 
       - name: Configure AWS credentials

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload catalog to S3
         run: |
           # Upload to temporary path
-          aws s3 sync catalogs/ s3://${{ secrets.S3_BUCKET_NAME }}/catalogs-new/ --delete --force
+          aws s3 sync catalogs/ s3://skypilot-catalog/catalogs-new/ --delete --force
           
           # Atomically move from temp to final path
-          aws s3 mv s3://${{ secrets.S3_BUCKET_NAME }}/catalogs-new/ s3://${{ secrets.S3_BUCKET_NAME }}/catalogs/ --recursive --force
+          aws s3 mv s3://skypilot-catalog/catalogs-new/ s3://skypilot-catalog/catalogs/ --recursive --force

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -1,0 +1,36 @@
+name: "upload-catalog-to-s3"
+on:
+  schedule:
+    - cron: '30 */7 * * *'    # Every 7 hours at minute 30
+  workflow_dispatch:
+
+jobs:
+  upload_to_s3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+          aws --version
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload catalog to S3
+        run: |
+          # Upload to temporary path
+          aws s3 sync catalogs/ s3://${{ secrets.S3_BUCKET_NAME }}/catalogs-new/ --delete --force
+          
+          # Atomically move from temp to final path
+          aws s3 mv s3://${{ secrets.S3_BUCKET_NAME }}/catalogs-new/ s3://${{ secrets.S3_BUCKET_NAME }}/catalogs/ --recursive --force

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FOR_SKYPILOT_CATALOG }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FOR_SKYPILOT_CATALOG }}
+          aws-region: ${{ secrets.AWS_REGION_FOR_SKYPILOT_CATALOG }}
 
       - name: Upload catalog to S3
         run: |

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -1,7 +1,7 @@
 name: "upload-catalog-to-s3"
 on:
   schedule:
-    - cron: '30 */7 * * *'    # Every 7 hours at minute 30
+    - cron: '50 */7 * * *'    # Every 7 hours at minute 50
   workflow_dispatch:
 
 jobs:
@@ -27,41 +27,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Create and configure public S3 bucket
-        run: |
-          # Try to create bucket and capture if it was created
-          if ! aws s3api head-bucket --bucket skypilot-catalog 2>/dev/null; then
-            echo "Bucket does not exist, creating it..."
-            aws s3api create-bucket --bucket skypilot-catalog --region ${{ secrets.AWS_REGION }}
-            
-            # Only set public access if bucket was just created
-            echo "Configuring public access for new bucket..."
-            aws s3api put-public-access-block \
-              --bucket skypilot-catalog \
-              --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
-            
-            aws s3api put-bucket-policy \
-              --bucket skypilot-catalog \
-              --policy '{
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Sid": "PublicReadGetObject",
-                    "Effect": "Allow",
-                    "Principal": "*",
-                    "Action": "s3:GetObject",
-                    "Resource": "arn:aws:s3:::skypilot-catalog/*"
-                  }
-                ]
-              }'
-          else
-            echo "Bucket already exists, skipping public access configuration"
-          fi
-
       - name: Upload catalog to S3
         run: |
-          # Upload to temporary path
-          aws s3 sync catalogs/ s3://skypilot-catalog/catalogs-new/ --delete --force
-          
-          # Atomically move from temp to final path
-          aws s3 mv s3://skypilot-catalog/catalogs-new/ s3://skypilot-catalog/catalogs/ --recursive --force
+          aws s3 sync catalogs/ s3://skypilot-catalog/catalogs/ --delete --force

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FOR_SKYPILOT_CATALOG }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FOR_SKYPILOT_CATALOG }}
-          aws-region: ${{ secrets.AWS_REGION_FOR_SKYPILOT_CATALOG }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FOR_HOSTED_CATALOG_MIRROR }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FOR_HOSTED_CATALOG_MIRROR }}
+          aws-region: ${{ secrets.AWS_REGION_FOR_HOSTED_CATALOG_MIRROR }}
 
       - name: Upload catalog to S3
         run: |

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -27,9 +27,36 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Create S3 bucket if not exists
+      - name: Create and configure public S3 bucket
         run: |
-          aws s3api head-bucket --bucket skypilot-catalog 2>/dev/null || aws s3api create-bucket --bucket skypilot-catalog --region ${{ secrets.AWS_REGION }}
+          # Try to create bucket and capture if it was created
+          if ! aws s3api head-bucket --bucket skypilot-catalog 2>/dev/null; then
+            echo "Bucket does not exist, creating it..."
+            aws s3api create-bucket --bucket skypilot-catalog --region ${{ secrets.AWS_REGION }}
+            
+            # Only set public access if bucket was just created
+            echo "Configuring public access for new bucket..."
+            aws s3api put-public-access-block \
+              --bucket skypilot-catalog \
+              --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+            
+            aws s3api put-bucket-policy \
+              --bucket skypilot-catalog \
+              --policy '{
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Sid": "PublicReadGetObject",
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "s3:GetObject",
+                    "Resource": "arn:aws:s3:::skypilot-catalog/*"
+                  }
+                ]
+              }'
+          else
+            echo "Bucket already exists, skipping public access configuration"
+          fi
 
       - name: Upload catalog to S3
         run: |

--- a/.github/workflows/upload-catalog-to-s3.yml
+++ b/.github/workflows/upload-catalog-to-s3.yml
@@ -27,6 +27,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Create S3 bucket if not exists
+        run: |
+          aws s3api head-bucket --bucket skypilot-catalog 2>/dev/null || aws s3api create-bucket --bucket skypilot-catalog --region ${{ secrets.AWS_REGION }}
+
       - name: Upload catalog to S3
         run: |
           # Upload to temporary path


### PR DESCRIPTION
See these links for details:
- https://github.com/skypilot-org/skypilot/pull/5622
- https://github.com/skypilot-org/skypilot/issues/5438

Due to GitHub's updated resource request limits, our catalog requests are getting many HTTP 429 errors. We need to create an S3 mirror for the catalog.

This PR creates a GitHub action that runs every 7 hours at minute 30, overwriting the master repo catalog to a public S3 bucket. Other workflows run every 7 hours at minute 15, so when this runs, those should be finished. (If not, the next 7-hour trigger will sync the latest version anyway.)

Works with this [PR](https://github.com/skypilot-org/skypilot/pull/5622) in the skypilot repo to fix the issue. Admins need to configure:
- `AWS_ACCESS_KEY_ID_FOR_HOSTED_CATALOG_MIRROR`
- `AWS_SECRET_ACCESS_KEY_FOR_HOSTED_CATALOG_MIRROR`
- `AWS_REGION_FOR_HOSTED_CATALOG_MIRROR` (`us-east-1`)

Tests:

https://github.com/zpoint/skypilot-catalog/actions/runs/15128235935/job/42524189450

<img width="1664" alt="image" src="https://github.com/user-attachments/assets/c0c56600-27fc-4d78-9ca0-ec5df5848b6b" />

Public access test:  
- `curl https://skypilot-catalog.s3.us-east-1.amazonaws.com/catalogs/v7/aws/vms.csv`   This URL works directly.