### PR TITLE
feat(runpod): Add RunPod catalog update cron

### DIFF
--- a/.github/workflows/update-runpod-catalog.yml
+++ b/.github/workflows/update-runpod-catalog.yml
@@ -1,0 +1,73 @@
+name: Update RunPod Catalog
+on:
+  schedule:
+    - cron: '00 */7 * * *' # Every 7 hours (coprimes with 24)
+    # The frequency can be tuned for the trade-off between
+    # freshness of the price and github action cost/user downloading
+    # overhead of the update.
+  workflow_dispatch:
+
+jobs:
+  update_runpod_catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone SkyPilot repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: skypilot-org/skypilot
+          path: sky
+      - name: Clone Catalog repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: catalogs
+          token: ${{ secrets.GH_ACTION_PAT }}
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: 'latest'
+          python-version: '3.10'
+      - name: Run fetch_runpod
+        id: fetch_catalogs
+        run: |
+          uv venv --seed ~/catalogs-venv
+          source ~/catalogs-venv/bin/activate
+          versions=$(cat catalogs/.metadata.yml | yq -r '.version_commit | keys[]')
+          # Loop over all versions and commit hashes
+          for version in $versions; do
+            # Find commit hash for the version
+            commit_hash=$(cat catalogs/.metadata.yml | yq -r ".version_commit.$version")
+            cd sky
+            if [ "$commit_hash" == "latest" ]; then
+              # Find the latest commit of the remote SkyPilot repo
+              commit_hash=$(git rev-parse origin/master)
+            fi
+            git checkout $commit_hash
+            uv pip install ".[runpod]"
+            cd -
+            echo "Fetching RunPod catalog for version $version, SkyPilot commit hash $commit_hash"
+            mkdir -p catalogs/catalogs/$version
+            cd catalogs/catalogs/$version
+            # Run the fetch script and verify the output file exists and is not empty
+            python -m sky.catalog.data_fetchers.fetch_runpod
+            if [ ! -f "runpod/vms.csv" ] || [ ! -s "runpod/vms.csv" ]; then
+              echo "Error: RunPod catalog file is missing or empty"
+              exit 1
+            fi
+            cd -
+          done
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+
+      - name: Commit catalog
+        run: |
+          versions=$(cat catalogs/.metadata.yml | yq -r '.version_commit | keys[]' | tr '\n' ', ')
+          cd catalogs
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m"[Bot] Update RunPod catalog $versions (scheduled at $(date))" || { echo "No changes to commit" && exit 0; }
+          git fetch origin
+          git rebase origin/master
+          git push


### PR DESCRIPTION
This a follow-up to #127. This is the script I used to generate the values of the previous manual update. This PR sets up a github action cron to automate the pricing updates.

Adds a workflow based on the one for AWS that automates the updating of RunPod GPU pricing and availability

Depends on https://github.com/skypilot-org/skypilot/pull/5930

The full CSV generated by the above is available here: https://gist.github.com/pirtleshell/41079b4c9752a16a60c3dbc45164e7c6

Running the workflow will require adding a read-only RunPod API key to the runner env with var named `RUNPOD_API_KEY`.

Opening as draft until skypilot PR has been reviewed & merged.