### PR TITLE
remove old docker image

### DIFF
--- a/catalogs/v5/kubernetes/images.csv
+++ b/catalogs/v5/kubernetes/images.csv
@@ -1,5 +1,5 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
-skypilot:cpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:20240613,20240613
-skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:20240613,20240613
+skypilot:cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20240613
+skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20240613
 skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20241031
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20241031

--- a/catalogs/v6/kubernetes/images.csv
+++ b/catalogs/v6/kubernetes/images.csv
@@ -1,5 +1,3 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
-skypilot:cpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:20240613,20240613
-skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:20240613,20240613
 skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20241031
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20241031

--- a/catalogs/v7/kubernetes/images.csv
+++ b/catalogs/v7/kubernetes/images.csv
@@ -1,5 +1,3 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
-skypilot:cpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:20240613,20240613
-skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:20240613,20240613
 skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20241031
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20241031

--- a/catalogs/v8/kubernetes/images.csv
+++ b/catalogs/v8/kubernetes/images.csv
@@ -1,5 +1,3 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
-skypilot:cpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:20240613,20240613
-skypilot:gpu-ubuntu-2004,,ubuntu,20.04,us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:20240613,20240613
 skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20241031
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20241031


### PR DESCRIPTION
These images are no longer available.

Retain the old name for catalog v5 as there may be some old versions of SkyPilot that will try to fetch the non-custom images.