### PR TITLE
Skip Lambda catalog versions that fail to fetch

### DIFF
--- a/.github/workflows/update-lambda-catalog.yml
+++ b/.github/workflows/update-lambda-catalog.yml
@@ -53,7 +53,18 @@ jobs:
             cd -
             mkdir -p catalogs/catalogs/$version
             cd catalogs/catalogs/$version
-            python -m sky.catalog.data_fetchers.fetch_lambda_cloud --api-key ${LAMBDA_API_KEY}
+            # v7 is pinned to an old commit whose fetcher can't handle newer
+            # Lambda API instance types (cpu_4x_generalx). Skip it on failure
+            # so v8 updates still go through.
+            if [ "$version" == "v7" ]; then
+              python -m sky.catalog.data_fetchers.fetch_lambda_cloud --api-key ${LAMBDA_API_KEY} || {
+                echo "Warning: Failed to update Lambda catalog for v7 (pinned commit too old), skipping."
+                cd -
+                continue
+              }
+            else
+              python -m sky.catalog.data_fetchers.fetch_lambda_cloud --api-key ${LAMBDA_API_KEY}
+            fi
             cd -
           done
         env:


### PR DESCRIPTION
## Summary
- The v7 catalog is pinned to an old SkyPilot commit (`6a9fed7b5`) whose Lambda fetcher doesn't handle the new `cpu_4x_generalx` instance type, causing `KeyError: 'GENERALX'`.
- This blocks the entire workflow including v8, even though v8 uses `latest` which has the fix (skypilot-org/skypilot#9556).
- Allow individual version failures to be skipped with a warning so v8 updates still go through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)