### PR TITLE
Repin v7 catalog to a commit that skips unreachable me-south-1

### DIFF
--- a/.metadata.yml
+++ b/.metadata.yml
@@ -2,7 +2,10 @@
 # for all versions listed here. We keep older versions for backward
 # compatibility.
 version_commit:
-  # This commit should be fixed, as any newer commit will be fetching v6
-  # catalogs
   v8: latest
-  v7: 6a9fed7b515c4c7dc0942da1c35c15f430a14e8e
+  # This commit must stay pinned to a v7-schema SkyPilot commit; any newer
+  # (v8-schema) commit would write v8-format catalogs into the v7 dir.
+  # Pinned to a v7-schema commit that also skips the currently-unreachable
+  # me-south-1 region (companion to skypilot#10095), so the scheduled fetch
+  # does not fail on the me-south-1 EC2 endpoint. Re-pin if v7 needs updates.
+  v7: ad1d5c452973643f5583542c603c2a16b94d3062


### PR DESCRIPTION
## Summary

The scheduled `update-aws-catalog` job loops over every version in `.metadata.yml`. It kept failing because:

- `v8: latest` already skips `me-south-1` (via skypilot-org/skypilot#10095) and passes.
- `v7` was pinned to an older **v7-schema** commit (`6a9fed7b5`) that still requests `me-south-1`, whose EC2 endpoint is currently unreachable (`Connect timeout on endpoint URL: https://ec2.me-south-1.amazonaws.com/`). `--check-all-regions-enabled-for-account` then hard-failed the job, so even the successful v8 fetch was never committed — both v7 and v8 AWS catalogs went stale.

We cannot repoint v7 at `latest`, since master is now v8-schema and would write v8-format CSVs into the v7 dir. Instead this repins v7 to a v7-schema commit that carries the same `me-south-1` skip: `skypilot-org/skypilot@ad1d5c452` (branch `catalog-v7-me-south-skip`, companion to skypilot-org/skypilot#10095).

Failing run: https://github.com/skypilot-org/skypilot-catalog/actions/runs/29221539722/job/86727491749

## Test plan

- The new v7 pin `ad1d5c452` is `6a9fed7b5` + the `me-south-1` comment-out only; `CATALOG_SCHEMA_VERSION` stays `v7`, so v7 clients keep receiving v7-format catalogs.
- After merge, re-run the `update-aws-catalog` workflow (`workflow_dispatch`) and confirm both v7 and v8 fetch + commit succeed without the me-south-1 endpoint error.

> Note: the v7 pin commit lives on the `catalog-v7-me-south-skip` branch in skypilot (not on master, since master is v8-schema). That branch must not be deleted, or the pinned SHA becomes unreachable to `actions/checkout`.