### PR TITLE
[Kubernetes] Pin default image tags to immutable images; add -v1

### DIFF
--- a/catalogs/v7/kubernetes/images.csv
+++ b/catalogs/v7/kubernetes/images.csv
@@ -1,5 +1,7 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
 skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20250909,20250909
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250909,20250909
-skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20260515
-skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20260515
+skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216,20260515
+skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216,20260515
+skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607160213,20260716
+skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607160213,20260716

--- a/catalogs/v8/kubernetes/images.csv
+++ b/catalogs/v8/kubernetes/images.csv
@@ -1,5 +1,7 @@
 Tag,Region,OS,OSVersion,ImageId,CreationDate
 skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20250909,20250909
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250909,20250909
-skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest,20260515
-skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest,20260515
+skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216,20260515
+skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216,20260515
+skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607160213,20260716
+skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607160213,20260716


### PR DESCRIPTION
## Summary
The default Kubernetes image rows `skypilot:custom-{cpu,gpu}-ubuntu-2204`
mapped to the **mutable `:latest`** tag, so every API-server version picked up
whatever image was published last. A breaking image change then reaches older
servers that assume the old image.

This pins images to **concrete, immutable tags** and versions the contract:
- Freeze `custom-*-ubuntu-2204` → `:202605150216` (the concrete image `:latest`
  currently resolves to) so existing/older servers keep their image.
- Add `custom-*-ubuntu-2204-v1` → the new image, which newer servers reference.

Applied to both `catalogs/v7/` and `catalogs/v8/kubernetes/images.csv`.

Companion to the SkyPilot change that bumps `IMAGE_CPU`/`IMAGE_GPU` to the
`-v1` tags.

> Note: the `-v1` rows should be repointed to the final published image tag
> before that SkyPilot change is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)