### PR TITLE
[Kubernetes] Repoint custom-*-ubuntu-2204-v1 to 202607220236

### DIFF
--- a/catalogs/v7/kubernetes/images.csv
+++ b/catalogs/v7/kubernetes/images.csv
@@ -3,5 +3,5 @@ skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skyp
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250909,20250909
 skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216,20260515
 skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216,20260515
-skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607160213,20260716
-skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607160213,20260716
+skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607220236,20260722
+skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607220236,20260722

--- a/catalogs/v8/kubernetes/images.csv
+++ b/catalogs/v8/kubernetes/images.csv
@@ -3,5 +3,5 @@ skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skyp
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250909,20250909
 skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216,20260515
 skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216,20260515
-skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607160213,20260716
-skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607160213,20260716
+skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607220236,20260722
+skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607220236,20260722


### PR DESCRIPTION
Repoint the `custom-*-ubuntu-2204-v1` default K8s image tags (CPU + GPU, in both `v7` and `v8`) from `202607160213` to the latest conda-free image build `202607220236`.

This is a routine repoint of the existing **v1** contract, not a new `-vN`: the v1 line already means "conda removed + default user venv", and this build only refreshes that same contract (adds interactive-SSH activation of the user venv and related fixes). So:

- Servers pinning `custom-*-ubuntu-2204-v1` pick up the newer image.
- Servers on the unsuffixed `custom-*-ubuntu-2204` tags stay frozen to `202605150216` and are unaffected.

Companion to the OSS change in skypilot-org/skypilot#10132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)