### PR TITLE
[Kubernetes] Repoint custom-*-ubuntu-2204-v1 to 202607240748

### DIFF
--- a/catalogs/v7/kubernetes/images.csv
+++ b/catalogs/v7/kubernetes/images.csv
@@ -3,5 +3,5 @@ skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skyp
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250909,20250909
 skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216,20260515
 skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216,20260515
-skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607220236,20260722
-skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607220236,20260722
+skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607240748,20260724
+skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607240748,20260724

--- a/catalogs/v8/kubernetes/images.csv
+++ b/catalogs/v8/kubernetes/images.csv
@@ -3,5 +3,5 @@ skypilot:custom-cpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skyp
 skypilot:custom-gpu-ubuntu-2004,,ubuntu,20.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250909,20250909
 skypilot:custom-cpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216,20260515
 skypilot:custom-gpu-ubuntu-2204,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216,20260515
-skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607220236,20260722
-skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607220236,20260722
+skypilot:custom-cpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202607240748,20260724
+skypilot:custom-gpu-ubuntu-2204-v1,,ubuntu,22.04,us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202607240748,20260724


### PR DESCRIPTION
## Summary
Repoint the `custom-cpu-ubuntu-2204-v1` and `custom-gpu-ubuntu-2204-v1` K8s image entries (v7 + v8) to the new build `202607240748`.

This build gates the default user-venv (`~/sky-user-env`) auto-activation in `~/.bashrc` on a TTY (`[ -t 0 ]`), so it only activates for real interactive `ssh <cluster>` sessions. Previously it also fired in the non-interactive task path (`bash -i <file>`), where `source activate` snapshotted PATH before cloud-CLI paths (e.g. gcloud's `path.bash.inc`, appended to `~/.bashrc` at runtime) were added; a later venv re-activation then restored that pre-CLI snapshot, dropping gcloud from PATH and causing the jobs controller to report "GCP access is disabled" on GCS storage prechecks.

## Changes
- `catalogs/v7/kubernetes/images.csv`: `custom-cpu/gpu-ubuntu-2204-v1` -> `202607240748`
- `catalogs/v8/kubernetes/images.csv`: `custom-cpu/gpu-ubuntu-2204-v1` -> `202607240748`

## Test
- Confirmed both `skypilot:202607240748` and `skypilot-gpu:202607240748` exist in the registry.
- Verified on a live pod that with the TTY guard, the real `make_task_bash_script` run under `bash -i` keeps `gcloud` on PATH.